### PR TITLE
Feature/change drive base to falcon

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -17,7 +17,6 @@ public final class Constants {
   public static final double SIMPLE_AUTON_SPEED = 0.2; // PLACEHOLDER
   public static final double SIMPLE_AUTON_RUNTIME = 5.0; // PLACEHOLDER
   public static final double MEDIUM_AUTON_OUTAKE_RUNTIME = 5.0; // PLACEHOLDER
-  public static final double DRIVEBASE_MOTORS_DEMAND = 1.0; // PLACEHOLDER
 
   /**
    * Stores constants related to driver controls, SmartDashboard and other IO (Input/Output).

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -17,6 +17,7 @@ public final class Constants {
   public static final double SIMPLE_AUTON_SPEED = 0.2; // PLACEHOLDER
   public static final double SIMPLE_AUTON_RUNTIME = 5.0; // PLACEHOLDER
   public static final double MEDIUM_AUTON_OUTAKE_RUNTIME = 5.0; // PLACEHOLDER
+  public static final double DRIVEBASE_MOTORS_DEMAND = 1.0; // PLACEHOLDER
 
   /**
    * Stores constants related to driver controls, SmartDashboard and other IO (Input/Output).

--- a/src/main/java/frc/robot/subsystems/DriveBase.java
+++ b/src/main/java/frc/robot/subsystems/DriveBase.java
@@ -21,7 +21,7 @@ public class DriveBase extends SubsystemBase {
   private final TalonFX rightFrontMotor;
   private final TalonFX rightBackMotor;
 
-  private NeutralMode leftFrontMotorNeutralMode;
+  private NeutralMode MotorNeutralMode;
 
   private final DifferentialDrive differentialDrive;
 
@@ -44,7 +44,7 @@ public class DriveBase extends SubsystemBase {
     initializeDriveMotor(rightFrontMotor);
     initializeDriveMotor(rightBackMotor);
 
-    leftFrontMotorNeutralMode = NeutralMode.Brake;
+    MotorNeutralMode = NeutralMode.Brake;
 
     differentialDrive =
         new DifferentialDrive(
@@ -70,7 +70,7 @@ public class DriveBase extends SubsystemBase {
    * Toggles the {@link NeutralMode} between Coast and Brake.
    */
   public void toggleBrakingMode() {
-    switch (leftFrontMotorNeutralMode) {
+    switch (MotorNeutralMode) {
       case Brake:
         setBrakingMode(NeutralMode.Coast);
         return;
@@ -91,7 +91,7 @@ public class DriveBase extends SubsystemBase {
     leftBackMotor.setNeutralMode(mode);
     rightFrontMotor.setNeutralMode(mode);
     rightBackMotor.setNeutralMode(mode);
-    leftFrontMotorNeutralMode = mode;
+    MotorNeutralMode = mode;
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/DriveBase.java
+++ b/src/main/java/frc/robot/subsystems/DriveBase.java
@@ -1,7 +1,6 @@
 
 package frc.robot.subsystems;
 
-import com.ctre.phoenix.motorcontrol.ControlMode;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.can.TalonFX;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
@@ -38,10 +37,6 @@ public class DriveBase extends SubsystemBase {
     rightFrontMotor = new WPI_TalonFX(rightFrontId);
     rightBackMotor = new WPI_TalonFX(rightBackId);
 
-    leftFrontMotor.set(ControlMode.PercentOutput, 0.0);
-    leftBackMotor.set(ControlMode.PercentOutput, 0.0);
-    rightFrontMotor.set(ControlMode.PercentOutput, 0.0);
-    rightBackMotor.set(ControlMode.PercentOutput, 0.0);
     setBrakingMode(NeutralMode.Brake);
 
     differentialDrive =

--- a/src/main/java/frc/robot/subsystems/DriveBase.java
+++ b/src/main/java/frc/robot/subsystems/DriveBase.java
@@ -21,7 +21,7 @@ public class DriveBase extends SubsystemBase {
   private final TalonFX rightFrontMotor;
   private final TalonFX rightBackMotor;
 
-  private NeutralMode MotorNeutralMode;
+  private NeutralMode motorNeutralMode;
 
   private final DifferentialDrive differentialDrive;
 
@@ -44,7 +44,7 @@ public class DriveBase extends SubsystemBase {
     initializeDriveMotor(rightFrontMotor);
     initializeDriveMotor(rightBackMotor);
 
-    MotorNeutralMode = NeutralMode.Brake;
+    motorNeutralMode = NeutralMode.Brake;
 
     differentialDrive =
         new DifferentialDrive(
@@ -70,7 +70,7 @@ public class DriveBase extends SubsystemBase {
    * Toggles the {@link NeutralMode} between Coast and Brake.
    */
   public void toggleBrakingMode() {
-    switch (MotorNeutralMode) {
+    switch (motorNeutralMode) {
       case Brake:
         setBrakingMode(NeutralMode.Coast);
         return;
@@ -91,7 +91,7 @@ public class DriveBase extends SubsystemBase {
     leftBackMotor.setNeutralMode(mode);
     rightFrontMotor.setNeutralMode(mode);
     rightBackMotor.setNeutralMode(mode);
-    MotorNeutralMode = mode;
+    motorNeutralMode = mode;
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/DriveBase.java
+++ b/src/main/java/frc/robot/subsystems/DriveBase.java
@@ -4,22 +4,21 @@ package frc.robot.subsystems;
 import com.ctre.phoenix.motorcontrol.ControlMode;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.can.TalonFX;
+import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
-import edu.wpi.first.wpilibj.motorcontrol.MotorController;
 import edu.wpi.first.wpilibj.motorcontrol.MotorControllerGroup;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.robot.Constants;
 
 /**
  * A subsystem that controls the drive train (aka chassis) on a robot.
  */
 public class DriveBase extends SubsystemBase {
 
-  private final TalonFX leftFrontMotor;
-  private final TalonFX leftBackMotor;
-  private final TalonFX rightFrontMotor;
-  private final TalonFX rightBackMotor;
+  private final WPI_TalonFX leftFrontMotor;
+  private final WPI_TalonFX leftBackMotor;
+  private final WPI_TalonFX rightFrontMotor;
+  private final WPI_TalonFX rightBackMotor;
 
   private NeutralMode motorNeutralMode;
 
@@ -34,36 +33,23 @@ public class DriveBase extends SubsystemBase {
    * @param rightBackId The CAN ID of the Right Back motor
    */
   public DriveBase(int leftFrontId, int leftBackId, int rightFrontId, int rightBackId) {
-    leftFrontMotor = new TalonFX(leftFrontId);
-    leftBackMotor = new TalonFX(leftBackId);
-    rightFrontMotor = new TalonFX(rightFrontId);
-    rightBackMotor = new TalonFX(rightBackId);
+    leftFrontMotor = new WPI_TalonFX(leftFrontId);
+    leftBackMotor = new WPI_TalonFX(leftBackId);
+    rightFrontMotor = new WPI_TalonFX(rightFrontId);
+    rightBackMotor = new WPI_TalonFX(rightBackId);
 
-    initializeDriveMotor(leftFrontMotor);
-    initializeDriveMotor(leftBackMotor);
-    initializeDriveMotor(rightFrontMotor);
-    initializeDriveMotor(rightBackMotor);
-
-    motorNeutralMode = NeutralMode.Brake;
+    leftFrontMotor.set(ControlMode.PercentOutput, 0.0);
+    leftBackMotor.set(ControlMode.PercentOutput, 0.0);
+    rightFrontMotor.set(ControlMode.PercentOutput, 0.0);
+    rightBackMotor.set(ControlMode.PercentOutput, 0.0);
+    setBrakingMode(NeutralMode.Brake);
 
     differentialDrive =
         new DifferentialDrive(
-            new MotorControllerGroup((MotorController) leftFrontMotor,
-                (MotorController) leftBackMotor),
-            new MotorControllerGroup((MotorController) rightFrontMotor,
-                (MotorController) rightBackMotor));
+            new MotorControllerGroup(leftFrontMotor, leftBackMotor),
+            new MotorControllerGroup(rightFrontMotor, rightBackMotor));
 
     CommandScheduler.getInstance().registerSubsystem(this);
-  }
-
-  /**
-   * Sets control mode, demand, and neutral mode of a given {@link TalonFX}.
-   *
-   * @param motor The motor to configure.
-   */
-  private void initializeDriveMotor(TalonFX motor) {
-    motor.set(ControlMode.PercentOutput, Constants.DRIVEBASE_MOTORS_DEMAND);
-    motor.setNeutralMode(NeutralMode.Brake);
   }
 
   /**

--- a/vendordeps/Phoenix.json
+++ b/vendordeps/Phoenix.json
@@ -1,0 +1,257 @@
+{
+    "fileName": "Phoenix.json",
+    "name": "CTRE-Phoenix",
+    "version": "5.21.1",
+    "frcYear": 2022,
+    "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
+    "mavenUrls": [
+        "https://maven.ctr-electronics.com/release/"
+    ],
+    "jsonUrl": "https://maven.ctr-electronics.com/release/com/ctre/phoenix/Phoenix-frc2022-latest.json",
+    "javaDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "api-java",
+            "version": "5.21.1"
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "wpiapi-java",
+            "version": "5.21.1"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "cci",
+            "version": "5.21.1",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "linuxathena"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "cci-sim",
+            "version": "5.21.1",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simTalonSRX",
+            "version": "5.21.1",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simTalonFX",
+            "version": "5.21.1",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simVictorSPX",
+            "version": "5.21.1",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simPigeonIMU",
+            "version": "5.21.1",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simCANCoder",
+            "version": "5.21.1",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        }
+    ],
+    "cppDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "wpiapi-cpp",
+            "version": "5.21.1",
+            "libName": "CTRE_Phoenix_WPI",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "api-cpp",
+            "version": "5.21.1",
+            "libName": "CTRE_Phoenix",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "cci",
+            "version": "5.21.1",
+            "libName": "CTRE_PhoenixCCI",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "wpiapi-cpp-sim",
+            "version": "5.21.1",
+            "libName": "CTRE_Phoenix_WPISim",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "api-cpp-sim",
+            "version": "5.21.1",
+            "libName": "CTRE_PhoenixSim",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "cci-sim",
+            "version": "5.21.1",
+            "libName": "CTRE_PhoenixCCISim",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simTalonSRX",
+            "version": "5.21.1",
+            "libName": "CTRE_SimTalonSRX",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simTalonFX",
+            "version": "5.21.1",
+            "libName": "CTRE_SimTalonFX",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simVictorSPX",
+            "version": "5.21.1",
+            "libName": "CTRE_SimVictorSPX",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simPigeonIMU",
+            "version": "5.21.1",
+            "libName": "CTRE_SimPigeonIMU",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simCANCoder",
+            "version": "5.21.1",
+            "libName": "CTRE_SimCANCoder",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Replaced CanSparkMax motors with TalonFX, used NeutralMode instead of IdleMode (added constant to keep track of motor neutral mode). Had to cast TalonFX to MotorController for DifferentialDrive -- was thinking about if we could make back motors follow front instead? 

Closes #61 