### PR TITLE
Feature/climber control improvements

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -107,8 +107,8 @@ public final class Constants {
     public static final int CLIMBER_TRIGGER_THRESHOLD = 100;
     public static final double CLIMBER_TRIGGER_THRESHOLD_TIME = 0.5;
 
-    public static final int CLIMBER_RETRACTED_POSITION = 0;
-    public static final int CLIMBER_EXTENDED_POSITION = 2048; // PLACEHOLDER
+    public static final double CLIMBER_RETRACTED_POSITION = 0.0;
+    public static final double CLIMBER_EXTENDED_POSITION = 2048.0; // PLACEHOLDER
   }
 
   /**

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -32,6 +32,8 @@ public final class Constants {
     public static final int TOWER_BUTTON_NUMBER = 6; // WEEK0
     public static final int CLIMBER_UP_BUTTON_NUMBER = 4; // WEEK0
     public static final int CLIMBER_DOWN_BUTTON_NUMBER = 1; // WEEK0
+    public static final int CLIMBER_RETRACT_BUTTON_NUMBER = 0; // PLACEHOLDER
+    public static final int CLIMBER_EXTEND_BUTTON_NUMBER = 1; // PLACEHOLDER
   }
 
   /**

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -108,7 +108,10 @@ public final class Constants {
     public static final double CLIMBER_TRIGGER_THRESHOLD_TIME = 0.5;
 
     public static final double CLIMBER_RETRACTED_POSITION = 0.0;
+    public static final double CLIMBER_RETRACTED_POSITION_ERROR = 256.0; // PLACEHOLDER
     public static final double CLIMBER_EXTENDED_POSITION = 2048.0; // PLACEHOLDER
+    public static final double CLIMBER_EXTENDED_POSITION_ERROR = 256.0; // PLACEHOLDER
+    public static final double CLIMBER_ALIGNMENT_ERROR = 256.0; // PLACEHOLDER
   }
 
   /**

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -48,14 +48,6 @@ public final class Constants {
 
       public static final int TOWER = 6; // WEEK0
 
-
-      public static final int OUTTAKE_BUTTON_NUMBER = 2; // WEEK0
-      public static final int TOWER_BUTTON_NUMBER = 6; // WEEK0
-      public static final int CLIMBER_UP_BUTTON_NUMBER = 4; // WEEK0
-      public static final int CLIMBER_DOWN_BUTTON_NUMBER = 1; // WEEK0
-      public static final int CLIMBER_RETRACT_BUTTON_NUMBER = 0; // PLACEHOLDER
-      public static final int CLIMBER_EXTEND_BUTTON_NUMBER = 1; // PLACEHOLDER
-
       public static final int CLIMBER_UP = 4; // WEEK0
       public static final int CLIMBER_DOWN = 1; // WEEK0
       public static final int OUTTAKE_BUTTON_NUMBER = 2; // WEEK0
@@ -150,12 +142,13 @@ public final class Constants {
     public static final int CURRENT_LIMIT = 85;
     public static final int TRIGGER_THRESHOLD = 100;
     public static final double TRIGGER_THRESHOLD_TIME = 0.5;
-    
+
     public static final double CLIMBER_RETRACTED_POSITION = 0.0;
     public static final double CLIMBER_RETRACTED_POSITION_ACCEPTABLE_ERROR = 256.0; // PLACEHOLDER
     public static final double CLIMBER_EXTENDED_POSITION = 2048.0; // PLACEHOLDER
     public static final double CLIMBER_EXTENDED_POSITION_ACCEPTABLE_ERROR = 256.0; // PLACEHOLDER
     public static final double CLIMBER_ALIGNMENT_ACCEPTABLE_ERROR = 256.0; // PLACEHOLDER
+    public static final int CLIMBER_SENSOR_PIDIDX_VALUE = 1; // PLACEHOLDER
   }
 
   /**

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -112,6 +112,8 @@ public final class Constants {
     public static final double CLIMBER_EXTENDED_POSITION = 2048.0; // PLACEHOLDER
     public static final double CLIMBER_EXTENDED_POSITION_ACCEPTABLE_ERROR = 256.0; // PLACEHOLDER
     public static final double CLIMBER_ALIGNMENT_ACCEPTABLE_ERROR = 256.0; // PLACEHOLDER
+
+    public static final int CLIMBER_SENSOR_PIDIDX_VALUE = 1;
   }
 
   /**

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -5,13 +5,13 @@
 package frc.robot;
 
 /**
- * The Constants class provides a convenient place for teams to hold robot-wide numerical or boolean
- * constants. This class should not be used for any other purpose. All constants should be declared
- * globally (i.e. public static). Do not put anything functional in this class.
+ * The Constants class provides a convenient place for teams to hold robot-wide numerical or boolean constants. This
+ * class should not be used for any other purpose. All constants should be declared globally (i.e. public static). Do
+ * not put anything functional in this class.
  *
  * <p>
- * It is advised to statically import this class (or one of its inner classes) wherever the
- * constants are needed, to reduce verbosity.
+ * It is advised to statically import this class (or one of its inner classes) wherever the constants are needed, to
+ * reduce verbosity.
  */
 public final class Constants {
   public static final double SIMPLE_AUTON_SPEED = 0.5; // WEEK0
@@ -104,6 +104,9 @@ public final class Constants {
     public static final int CLIMBER_CURRENT_LIMIT = 85;
     public static final int CLIMBER_TRIGGER_THRESHOLD = 100;
     public static final double CLIMBER_TRIGGER_THRESHOLD_TIME = 0.5;
+
+    public static final int CLIMBER_RETRACTED_POSITION = 0;
+    public static final int CLIMBER_EXTENDED_POSITION = 2048; // PLACEHOLDER
   }
 
   /**

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -108,10 +108,10 @@ public final class Constants {
     public static final double CLIMBER_TRIGGER_THRESHOLD_TIME = 0.5;
 
     public static final double CLIMBER_RETRACTED_POSITION = 0.0;
-    public static final double CLIMBER_RETRACTED_POSITION_ERROR = 256.0; // PLACEHOLDER
+    public static final double CLIMBER_RETRACTED_POSITION_ACCEPTABLE_ERROR = 256.0; // PLACEHOLDER
     public static final double CLIMBER_EXTENDED_POSITION = 2048.0; // PLACEHOLDER
-    public static final double CLIMBER_EXTENDED_POSITION_ERROR = 256.0; // PLACEHOLDER
-    public static final double CLIMBER_ALIGNMENT_ERROR = 256.0; // PLACEHOLDER
+    public static final double CLIMBER_EXTENDED_POSITION_ACCEPTABLE_ERROR = 256.0; // PLACEHOLDER
+    public static final double CLIMBER_ALIGNMENT_ACCEPTABLE_ERROR = 256.0; // PLACEHOLDER
   }
 
   /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -81,7 +81,7 @@ public class RobotContainer {
       new JoystickButton(secondaryDriverJoystick, IOConstants.CLIMBER_DOWN_BUTTON_NUMBER);
   private final JoystickButton climberRetractButton =
       new JoystickButton(secondaryDriverJoystick, IOConstants.CLIMBER_RETRACT_BUTTON_NUMBER);
-  private final JoystickButton climberEntendButton =
+  private final JoystickButton climberExtendButton =
       new JoystickButton(secondaryDriverJoystick, IOConstants.CLIMBER_EXTEND_BUTTON_NUMBER);
 
   /**
@@ -119,7 +119,7 @@ public class RobotContainer {
     climberRetractButton
         .whileHeld(
             new RunClimberToPositionCommand(climber, ClimberConstants.CLIMBER_RETRACTED_POSITION));
-    climberEntendButton
+    climberExtendButton
         .whileHeld(
             new RunClimberToPositionCommand(climber, ClimberConstants.CLIMBER_EXTENDED_POSITION));
   }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -13,18 +13,18 @@ import edu.wpi.first.wpilibj2.command.WaitCommand;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 import frc.robot.Constants.AutonConstants;
 import frc.robot.Constants.ClimberConstants;
-import frc.robot.Constants.DriveConstants;
-import frc.robot.Constants.IOConstants;
-import frc.robot.Constants.IntakeConstants;
-import frc.robot.Constants.OuttakeConstants;
-import frc.robot.Constants.TowerConstants;
 import frc.robot.Constants.ClimberConstants.ClimberMotorCANIDs;
+import frc.robot.Constants.DriveConstants;
 import frc.robot.Constants.DriveConstants.DriveMotorCANIDs;
+import frc.robot.Constants.IOConstants;
 import frc.robot.Constants.IOConstants.DriverAxes;
 import frc.robot.Constants.IOConstants.DriverButtons;
 import frc.robot.Constants.IOConstants.OperatorButtons;
+import frc.robot.Constants.IntakeConstants;
 import frc.robot.Constants.IntakeConstants.IntakeSolenoidChannels;
+import frc.robot.Constants.OuttakeConstants;
 import frc.robot.Constants.OuttakeConstants.OuttakeMotorCANIDs;
+import frc.robot.Constants.TowerConstants;
 import frc.robot.Constants.TowerConstants.TowerMotorCANIDs;
 import frc.robot.commands.auton.SimpleAutonCommand;
 import frc.robot.commands.climber.RunClimberCommand;
@@ -81,8 +81,10 @@ public class RobotContainer {
   private final JoystickButton towerButton = operatorJoystick.button(OperatorButtons.TOWER);
   private final JoystickButton climberUpButton = operatorJoystick.button(OperatorButtons.CLIMBER_UP);
   private final JoystickButton climberDownButton = operatorJoystick.button(OperatorButtons.CLIMBER_DOWN);
-  private final JoystickButton climberRetractButton = operatorJoystick.button(OperatorButtons.CLIMBER_RETRACT_BUTTON_NUMBER);
-  private final JoystickButton climberExtendButton = operatorJoystick.button(OperatorButtons..CLIMBER_EXTEND_BUTTON_NUMBER);
+  private final JoystickButton climberRetractButton =
+      operatorJoystick.button(OperatorButtons.CLIMBER_RETRACT_BUTTON_NUMBER);
+  private final JoystickButton climberExtendButton =
+      operatorJoystick.button(OperatorButtons.CLIMBER_EXTEND_BUTTON_NUMBER);
 
   /**
    * The container for the robot. Contains subsystems, OI devices, and commands.
@@ -117,7 +119,7 @@ public class RobotContainer {
     climberExtendButton
         .whileHeld(
             new RunClimberToPositionCommand(climber, ClimberConstants.CLIMBER_EXTENDED_POSITION));
-   
+
   }
 
   // A simple auto routine.

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -20,6 +20,7 @@ import frc.robot.Constants.IntakeConstants;
 import frc.robot.Constants.TowerConstants;
 import frc.robot.commands.auton.SimpleAutonCommand;
 import frc.robot.commands.climber.RunClimberCommand;
+import frc.robot.commands.climber.RunClimberToPositionCommand;
 import frc.robot.commands.drive.StopDriveCommand;
 import frc.robot.commands.drive.TankDriveCommand;
 import frc.robot.commands.intake.ExtendIntakeCommand;
@@ -115,6 +116,12 @@ public class RobotContainer {
         .whileHeld(new TankDriveCommand(driveBase,
             () -> DriveConstants.SLOWDOWN_PERCENT * primaryDriverJoystick.getRawAxis(1),
             () -> DriveConstants.SLOWDOWN_PERCENT * primaryDriverJoystick.getRawAxis(3)));
+    climberRetractButton
+        .whileHeld(
+            new RunClimberToPositionCommand(climber, ClimberConstants.CLIMBER_RETRACTED_POSITION));
+    climberEntendButton
+        .whileHeld(
+            new RunClimberToPositionCommand(climber, ClimberConstants.CLIMBER_EXTENDED_POSITION));
   }
 
   // A simple auto routine.

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -33,10 +33,9 @@ import frc.robot.subsystems.Outtake;
 import frc.robot.subsystems.Tower;
 
 /**
- * This class is where the bulk of the robot should be declared. Since Command-based is a
- * "declarative" paradigm, very little robot logic should actually be handled in the {@link Robot}
- * periodic methods (other than the scheduler calls). Instead, the structure of the robot (including
- * subsystems, commands, and button mappings) should be declared here.
+ * This class is where the bulk of the robot should be declared. Since Command-based is a "declarative" paradigm, very
+ * little robot logic should actually be handled in the {@link Robot} periodic methods (other than the scheduler calls).
+ * Instead, the structure of the robot (including subsystems, commands, and button mappings) should be declared here.
  */
 public class RobotContainer {
   // The robot's subsystems and commands are defined here...
@@ -79,6 +78,10 @@ public class RobotContainer {
       new JoystickButton(secondaryDriverJoystick, IOConstants.CLIMBER_UP_BUTTON_NUMBER);
   private final JoystickButton climberDownButton =
       new JoystickButton(secondaryDriverJoystick, IOConstants.CLIMBER_DOWN_BUTTON_NUMBER);
+  private final JoystickButton climberRetractButton =
+      new JoystickButton(secondaryDriverJoystick, IOConstants.CLIMBER_RETRACT_BUTTON_NUMBER);
+  private final JoystickButton climberEntendButton =
+      new JoystickButton(secondaryDriverJoystick, IOConstants.CLIMBER_EXTEND_BUTTON_NUMBER);
 
   /**
    * The container for the robot. Contains subsystems, OI devices, and commands.
@@ -90,10 +93,9 @@ public class RobotContainer {
   }
 
   /**
-   * Use this method to define your button->command mappings. Buttons can be created by
-   * instantiating a {@link GenericHID} or one of its subclasses
-   * ({@link edu.wpi.first.wpilibj.Joystick} or {@link XboxController}), and then passing it to a
-   * {@link edu.wpi.first.wpilibj2.command.button.JoystickButton}.
+   * Use this method to define your button->command mappings. Buttons can be created by instantiating a
+   * {@link GenericHID} or one of its subclasses ({@link edu.wpi.first.wpilibj.Joystick} or {@link XboxController}), and
+   * then passing it to a {@link edu.wpi.first.wpilibj2.command.button.JoystickButton}.
    */
   private void configureButtonBindings() {
     outtakeButton
@@ -150,9 +152,9 @@ public class RobotContainer {
   }
 
   /**
-   * Robot.java should run this method when teleop starts. This method should be used to set the
-   * default commands for subsystems while in teleop. If you set a default here, set a corresponding
-   * auton default in setAutonDefaultCommands().
+   * Robot.java should run this method when teleop starts. This method should be used to set the default commands for
+   * subsystems while in teleop. If you set a default here, set a corresponding auton default in
+   * setAutonDefaultCommands().
    */
   public void setTeleopDefaultCommands() {
     driveBase.setDefaultCommand(
@@ -163,9 +165,9 @@ public class RobotContainer {
   }
 
   /**
-   * Robot.java should run this method when auton starts. This method should be used to set the
-   * default commands for subsystems while in auton. If you set a default here, set a corresponding
-   * teleop default in setTeleopDefaultCommands().
+   * Robot.java should run this method when auton starts. This method should be used to set the default commands for
+   * subsystems while in auton. If you set a default here, set a corresponding teleop default in
+   * setTeleopDefaultCommands().
    */
   public void setAutonDefaultCommands() {
     driveBase.setDefaultCommand(new StopDriveCommand(driveBase));

--- a/src/main/java/frc/robot/commands/climber/RunClimberToPositionCommand.java
+++ b/src/main/java/frc/robot/commands/climber/RunClimberToPositionCommand.java
@@ -1,0 +1,45 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.climber;
+
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.subsystems.Climber;
+
+
+/**
+ * Runs the {@link Climber} to a specified position.
+ */
+public class RunClimberToPositionCommand extends CommandBase {
+  private final Climber climber;
+  private final double position;
+
+  /**
+   * Runs the {@link Climber} to a certain position.
+   *
+   * @param climber The {@link Climber} to run
+   * @param position The position to go to
+   * @return
+   */
+  public RunClimberToPositionCommand(Climber climber, double position) {
+    this.climber = climber;
+    this.position = position;
+    addRequirements(this.climber);
+  }
+
+  @Override
+  public void execute() {
+    climber.setPosition(position);
+  }
+
+  @Override
+  public void end(boolean interrupted) {
+    climber.setSpeed(0);
+  }
+
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/commands/climber/RunOneClimberCommand.java
+++ b/src/main/java/frc/robot/commands/climber/RunOneClimberCommand.java
@@ -1,0 +1,64 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.climber;
+
+import java.util.function.Supplier;
+
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.subsystems.Climber;
+
+
+/**
+ * Runs the {@link Climber}.
+ */
+public class RunOneClimberCommand extends CommandBase {
+  private final Climber climber;
+  private final Supplier<Double> speedSupplier;
+  private final int leftOrRight;
+
+  /**
+   * Runs the {@link Climber} at the given speed.
+   *
+   * @param climber The {@link Climber} to run
+   * @param speed The speed to run at
+   * @param leftOrRight 0 controls left motor, 1 controls right
+   */
+  public RunOneClimberCommand(Climber climber, double speed, int leftOrRight) {
+    this(climber, () -> speed, leftOrRight);
+  }
+
+  /**
+   * Runs the {@link Climber} at the speed given by the supplier.
+   *
+   * @param climber The {@link Climber} to run
+   * @param speedSupplier Supplier for the speed to run at
+   * @param leftOrRight 0 controls left motor, 1 controls right
+   */
+  public RunOneClimberCommand(Climber climber, Supplier<Double> speedSupplier, int leftOrRight) {
+    this.climber = climber;
+    this.speedSupplier = speedSupplier;
+    this.leftOrRight = leftOrRight;
+    addRequirements(this.climber);
+  }
+
+  @Override
+  public void execute() {
+    if (leftOrRight == 0) {
+      climber.setLeftSpeed(speedSupplier.get());
+    } else if (leftOrRight == 1) {
+      climber.setRightSpeed(speedSupplier.get());
+    }
+  }
+
+  @Override
+  public void end(boolean interrupted) {
+    climber.setSpeed(0);
+  }
+
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/commands/climber/RunOneClimberPositionCommand.java
+++ b/src/main/java/frc/robot/commands/climber/RunOneClimberPositionCommand.java
@@ -30,7 +30,7 @@ public class RunOneClimberPositionCommand extends CommandBase {
   }
 
   /**
-   * Runs the {@link Climber} at the speed given by the supplier.
+   * Runs the {@link Climber} at the position given by the supplier.
    *
    * @param climber The {@link Climber} to run
    * @param positionSupplier Supplier for the position to go to
@@ -46,9 +46,9 @@ public class RunOneClimberPositionCommand extends CommandBase {
   @Override
   public void execute() {
     if (leftOrRight == 0) {
-      climber.setLeftSpeed(positionSupplier.get());
+      climber.setLeftPosition(positionSupplier.get());
     } else if (leftOrRight == 1) {
-      climber.setRightSpeed(positionSupplier.get());
+      climber.setRightPosition(positionSupplier.get());
     }
   }
 

--- a/src/main/java/frc/robot/commands/climber/RunOneClimberPositionCommand.java
+++ b/src/main/java/frc/robot/commands/climber/RunOneClimberPositionCommand.java
@@ -13,32 +13,32 @@ import frc.robot.subsystems.Climber;
 /**
  * Runs the {@link Climber}.
  */
-public class RunOneClimberCommand extends CommandBase {
+public class RunOneClimberPositionCommand extends CommandBase {
   private final Climber climber;
-  private final Supplier<Double> speedSupplier;
+  private final Supplier<Double> positionSupplier;
   private final int leftOrRight;
 
   /**
    * Runs the {@link Climber} at the given speed.
    *
    * @param climber The {@link Climber} to run
-   * @param speed The speed to run at
+   * @param position The position to go to
    * @param leftOrRight 0 controls left motor, 1 controls right
    */
-  public RunOneClimberCommand(Climber climber, double speed, int leftOrRight) {
-    this(climber, () -> speed, leftOrRight);
+  public RunOneClimberPositionCommand(Climber climber, double position, int leftOrRight) {
+    this(climber, () -> position, leftOrRight);
   }
 
   /**
    * Runs the {@link Climber} at the speed given by the supplier.
    *
    * @param climber The {@link Climber} to run
-   * @param speedSupplier Supplier for the speed to run at
+   * @param positionSupplier Supplier for the position to go to
    * @param leftOrRight 0 controls left motor, 1 controls right
    */
-  public RunOneClimberCommand(Climber climber, Supplier<Double> speedSupplier, int leftOrRight) {
+  public RunOneClimberPositionCommand(Climber climber, Supplier<Double> positionSupplier, int leftOrRight) {
     this.climber = climber;
-    this.speedSupplier = speedSupplier;
+    this.positionSupplier = positionSupplier;
     this.leftOrRight = leftOrRight;
     addRequirements(this.climber);
   }
@@ -46,9 +46,9 @@ public class RunOneClimberCommand extends CommandBase {
   @Override
   public void execute() {
     if (leftOrRight == 0) {
-      climber.setLeftSpeed(speedSupplier.get());
+      climber.setLeftSpeed(positionSupplier.get());
     } else if (leftOrRight == 1) {
-      climber.setRightSpeed(speedSupplier.get());
+      climber.setRightSpeed(positionSupplier.get());
     }
   }
 

--- a/src/main/java/frc/robot/commands/climber/RunOneClimberSpeedCommand.java
+++ b/src/main/java/frc/robot/commands/climber/RunOneClimberSpeedCommand.java
@@ -1,0 +1,64 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.climber;
+
+import java.util.function.Supplier;
+
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.subsystems.Climber;
+
+
+/**
+ * Runs the {@link Climber}.
+ */
+public class RunOneClimberSpeedCommand extends CommandBase {
+  private final Climber climber;
+  private final Supplier<Double> speedSupplier;
+  private final int leftOrRight;
+
+  /**
+   * Runs the {@link Climber} at the given speed.
+   *
+   * @param climber The {@link Climber} to run
+   * @param speed The speed to run at
+   * @param leftOrRight 0 controls left motor, 1 controls right
+   */
+  public RunOneClimberSpeedCommand(Climber climber, double speed, int leftOrRight) {
+    this(climber, () -> speed, leftOrRight);
+  }
+
+  /**
+   * Runs the {@link Climber} at the speed given by the supplier.
+   *
+   * @param climber The {@link Climber} to run
+   * @param speedSupplier Supplier for the speed to run at
+   * @param leftOrRight 0 controls left motor, 1 controls right
+   */
+  public RunOneClimberSpeedCommand(Climber climber, Supplier<Double> speedSupplier, int leftOrRight) {
+    this.climber = climber;
+    this.speedSupplier = speedSupplier;
+    this.leftOrRight = leftOrRight;
+    addRequirements(this.climber);
+  }
+
+  @Override
+  public void execute() {
+    if (leftOrRight == 0) {
+      climber.setLeftSpeed(speedSupplier.get());
+    } else if (leftOrRight == 1) {
+      climber.setRightSpeed(speedSupplier.get());
+    }
+  }
+
+  @Override
+  public void end(boolean interrupted) {
+    climber.setSpeed(0);
+  }
+
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -48,4 +48,15 @@ public class Climber extends SubsystemBase {
     rightClimberMotor.set(ControlMode.PercentOutput, speed);
   }
 
+  /**
+   * Set the position of the left and right Climber motors in Position Control Mode.
+   *
+   * @param position The speed to set both Climber motors to
+   */
+  public void setPosition(double position) {
+    leftClimberMotor.set(ControlMode.Position, position);
+    rightClimberMotor.set(ControlMode.Position, position);
+  }
+
+
 }

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -120,5 +120,40 @@ public class Climber extends SubsystemBase {
     return getLeftMotorPosition() - getRightMotorPosition();
   }
 
+  /**
+   * Set the speed of the left Climber motor in PercentOutput.
+   *
+   * @param speed The speed to set climber to
+   */
+  public void setLeftSpeed(double speed) {
+    leftClimberMotor.set(ControlMode.PercentOutput, speed);
+  }
+
+  /**
+   * Set the speed of the right Climber motor in PercentOutput.
+   *
+   * @param speed The speed to set right climber to
+   */
+  public void setRightSpeed(double speed) {
+    rightClimberMotor.set(ControlMode.PercentOutput, speed);
+  }
+
+  /**
+   * Set the position of the left Climber motor.
+   *
+   * @param position The position to set left climber to
+   */
+  public void setLeftPosition(double position) {
+    leftClimberMotor.set(ControlMode.Position, position);
+  }
+
+  /**
+   * Set the position of the right CLimber motor.
+   *
+   * @param position The position to set right climber to
+   */
+  public void setRightPosition(double position) {
+    rightClimberMotor.set(ControlMode.Position, position);
+  }
 
 }

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -63,7 +63,7 @@ public class Climber extends SubsystemBase {
    *
    */
   public double getLeftMotorPosition() {
-    return leftClimberMotor.getSelectedSensorPosition(1);
+    return leftClimberMotor.getSelectedSensorPosition(Constants.ClimberConstants.CLIMBER_SENSOR_PIDIDX_VALUE);
   }
 
   /**
@@ -71,7 +71,7 @@ public class Climber extends SubsystemBase {
    *
    */
   public double getRightMotorPosition() {
-    return rightClimberMotor.getSelectedSensorPosition(1);
+    return rightClimberMotor.getSelectedSensorPosition(Constants.ClimberConstants.CLIMBER_SENSOR_PIDIDX_VALUE);
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -63,7 +63,7 @@ public class Climber extends SubsystemBase {
    *
    */
   public double getLeftMotorPosition() {
-    return leftClimberMotor.getSelectedSensorPosition(Constants.ClimberConstants.CLIMBER_SENSOR_PIDIDX_VALUE);
+    return leftClimberMotor.getSelectedSensorPosition(ClimberConstants.CLIMBER_SENSOR_PIDIDX_VALUE);
   }
 
   /**
@@ -71,7 +71,7 @@ public class Climber extends SubsystemBase {
    *
    */
   public double getRightMotorPosition() {
-    return rightClimberMotor.getSelectedSensorPosition(Constants.ClimberConstants.CLIMBER_SENSOR_PIDIDX_VALUE);
+    return rightClimberMotor.getSelectedSensorPosition(ClimberConstants.CLIMBER_SENSOR_PIDIDX_VALUE);
   }
 
   /**
@@ -80,7 +80,7 @@ public class Climber extends SubsystemBase {
    */
   public boolean isRetracted() {
     if (Math.abs(getLeftMotorPosition()
-        - Constants.ClimberConstants.CLIMBER_RETRACTED_POSITION) < Constants.ClimberConstants.CLIMBER_RETRACTED_POSITION_ACCEPTABLE_ERROR) {
+        - ClimberConstants.CLIMBER_RETRACTED_POSITION) < ClimberConstants.CLIMBER_RETRACTED_POSITION_ACCEPTABLE_ERROR) {
       return true;
     } else {
       return false;
@@ -93,7 +93,7 @@ public class Climber extends SubsystemBase {
    */
   public boolean isExtended() {
     if (Math.abs(getLeftMotorPosition()
-        - Constants.ClimberConstants.CLIMBER_EXTENDED_POSITION) < Constants.ClimberConstants.CLIMBER_EXTENDED_POSITION_ACCEPTABLE_ERROR) {
+        - ClimberConstants.CLIMBER_EXTENDED_POSITION) < ClimberConstants.CLIMBER_EXTENDED_POSITION_ACCEPTABLE_ERROR) {
       return true;
     } else {
       return false;
@@ -105,7 +105,7 @@ public class Climber extends SubsystemBase {
    *
    */
   public boolean isAligned() {
-    if (Math.abs(getAlignmentDifference()) < Constants.ClimberConstants.CLIMBER_ALIGNMENT_ACCEPTABLE_ERROR) {
+    if (Math.abs(getAlignmentDifference()) < ClimberConstants.CLIMBER_ALIGNMENT_ACCEPTABLE_ERROR) {
       return true;
     } else {
       return false;

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -58,5 +58,68 @@ public class Climber extends SubsystemBase {
     rightClimberMotor.set(ControlMode.Position, position);
   }
 
+  /**
+   * Get the position of the left Climber motor.
+   *
+   */
+  public double getLeftMotorPosition() {
+    return leftClimberMotor.getSelectedSensorPosition(1);
+  }
+
+  /**
+   * Get the position of the right Climber motor.
+   *
+   */
+  public double getRightMotorPosition() {
+    return rightClimberMotor.getSelectedSensorPosition(1);
+  }
+
+  /**
+   * Returns true if the position of the left climber motor is close enough to the retracted position.
+   *
+   */
+  public boolean isRetracted() {
+    if (Math.abs(leftClimberMotor.getSelectedSensorPosition(1)
+        - Constants.ClimberConstants.CLIMBER_RETRACTED_POSITION) < Constants.ClimberConstants.CLIMBER_RETRACTED_POSITION_ERROR) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * Returns true if the position of the left climber motor is close enough to the extended position.
+   *
+   */
+  public boolean isExtended() {
+    if (Math.abs(leftClimberMotor.getSelectedSensorPosition(1)
+        - Constants.ClimberConstants.CLIMBER_EXTENDED_POSITION) < Constants.ClimberConstants.CLIMBER_EXTENDED_POSITION_ERROR) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * Returns true if the absolute value distance in position between the two climbers is below a certain value.
+   *
+   */
+  public boolean isAligned() {
+    if (Math.abs(leftClimberMotor.getSelectedSensorPosition(1)
+        - rightClimberMotor.getSelectedSensorPosition(1)) < Constants.ClimberConstants.CLIMBER_ALIGNMENT_ERROR) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * Returns difference in position between the left and right climber motors.
+   *
+   */
+  public double getAlignmentDifference() {
+    return leftClimberMotor.getSelectedSensorPosition(1) - rightClimberMotor.getSelectedSensorPosition(1);
+  }
+
 
 }

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -49,9 +49,9 @@ public class Climber extends SubsystemBase {
   }
 
   /**
-   * Set the position of the left and right Climber motors in Position Control Mode.
+   * Set the position that the left and right Climber motors need to go to.
    *
-   * @param position The speed to set both Climber motors to
+   * @param position The position both Climber motors need to go to
    */
   public void setPosition(double position) {
     leftClimberMotor.set(ControlMode.Position, position);

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -79,8 +79,8 @@ public class Climber extends SubsystemBase {
    *
    */
   public boolean isRetracted() {
-    if (Math.abs(leftClimberMotor.getSelectedSensorPosition(1)
-        - Constants.ClimberConstants.CLIMBER_RETRACTED_POSITION) < Constants.ClimberConstants.CLIMBER_RETRACTED_POSITION_ERROR) {
+    if (Math.abs(getLeftMotorPosition()
+        - Constants.ClimberConstants.CLIMBER_RETRACTED_POSITION) < Constants.ClimberConstants.CLIMBER_RETRACTED_POSITION_ACCEPTABLE_ERROR) {
       return true;
     } else {
       return false;
@@ -92,8 +92,8 @@ public class Climber extends SubsystemBase {
    *
    */
   public boolean isExtended() {
-    if (Math.abs(leftClimberMotor.getSelectedSensorPosition(1)
-        - Constants.ClimberConstants.CLIMBER_EXTENDED_POSITION) < Constants.ClimberConstants.CLIMBER_EXTENDED_POSITION_ERROR) {
+    if (Math.abs(getLeftMotorPosition()
+        - Constants.ClimberConstants.CLIMBER_EXTENDED_POSITION) < Constants.ClimberConstants.CLIMBER_EXTENDED_POSITION_ACCEPTABLE_ERROR) {
       return true;
     } else {
       return false;
@@ -105,8 +105,7 @@ public class Climber extends SubsystemBase {
    *
    */
   public boolean isAligned() {
-    if (Math.abs(leftClimberMotor.getSelectedSensorPosition(1)
-        - rightClimberMotor.getSelectedSensorPosition(1)) < Constants.ClimberConstants.CLIMBER_ALIGNMENT_ERROR) {
+    if (Math.abs(getAlignmentDifference()) < Constants.ClimberConstants.CLIMBER_ALIGNMENT_ACCEPTABLE_ERROR) {
       return true;
     } else {
       return false;
@@ -114,11 +113,11 @@ public class Climber extends SubsystemBase {
   }
 
   /**
-   * Returns difference in position between the left and right climber motors.
+   * Returns the right motor position subtracted from the left motor position.
    *
    */
   public double getAlignmentDifference() {
-    return leftClimberMotor.getSelectedSensorPosition(1) - rightClimberMotor.getSelectedSensorPosition(1);
+    return getLeftMotorPosition() - getRightMotorPosition();
   }
 
 


### PR DESCRIPTION
Note: Could use Follow Control Mode to make one motor follow another (maybe when a button is pressed??). But I did not include this in the PR. 
- Adds setPosition method (of both motors)

**Methods which get the position of one motor:**
- Adds getLeftMotorPosition method
- Adds getRightMotorPosition method

**Methods which check whether a climber is extended or retracted:**
- Adds isRetracted method
- Adds isExtended method

**Methods related to the alignment of the two talon fx (in relation to encoder position value change from the start):**
- Adds isAligned method
- Adds getAlignmentDifference method

**Methods which control the speed of one motor:**
- Adds setLeftSpeed method
- Adds setRightSpeed method

**Methods which control the position of one motor (units are in native units as other units not supported):**
- Adds setLeftPosition method
- Adds setRightPosition method

**Commands:**
- Adds RunClimberToPositionCommand and implements it
- Adds RunOneClimberPositionCommand
- Adds RunOneClimberSpeedCommand